### PR TITLE
Add video upscaling option

### DIFF
--- a/Jellyfin.Server/Migrations/PreStartupRoutines/MigrateEncodingOptions.cs
+++ b/Jellyfin.Server/Migrations/PreStartupRoutines/MigrateEncodingOptions.cs
@@ -136,7 +136,9 @@ public class MigrateEncodingOptions : IMigrationRoutine
             AllowAv1Encoding = oldConfig.AllowAv1Encoding,
             EnableSubtitleExtraction = oldConfig.EnableSubtitleExtraction,
             HardwareDecodingCodecs = oldConfig.HardwareDecodingCodecs,
-            AllowOnDemandMetadataBasedKeyframeExtractionForExtensions = oldConfig.AllowOnDemandMetadataBasedKeyframeExtractionForExtensions
+            AllowOnDemandMetadataBasedKeyframeExtractionForExtensions = oldConfig.AllowOnDemandMetadataBasedKeyframeExtractionForExtensions,
+            EnableUpscaling = false,
+            UpscaleMode = UpscaleMode.FullHD1080p
         };
 
         var newSerializer = new XmlSerializer(typeof(EncodingOptions));
@@ -235,5 +237,9 @@ public class MigrateEncodingOptions : IMigrationRoutine
         public string[] HardwareDecodingCodecs { get; set; }
 
         public string[] AllowOnDemandMetadataBasedKeyframeExtractionForExtensions { get; set; }
+
+        public bool EnableUpscaling { get; set; }
+
+        public UpscaleMode UpscaleMode { get; set; }
     }
 }

--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -3416,6 +3416,27 @@ namespace MediaBrowser.Controller.MediaEncoding
                     targetAr);
             }
 
+            if (options.EnableUpscaling
+                && videoWidth.HasValue && videoHeight.HasValue
+                && !requestedWidth.HasValue && !requestedHeight.HasValue
+                && !requestedMaxWidth.HasValue && !requestedMaxHeight.HasValue)
+            {
+                var target = options.UpscaleMode == UpscaleMode.UHD4K
+                    ? (Width: 3840, Height: 2160)
+                    : (Width: 1920, Height: 1080);
+
+                if (videoWidth.Value < target.Width || videoHeight.Value < target.Height)
+                {
+                    var scaleW = (double)target.Width / videoWidth.Value;
+                    var scaleH = (double)target.Height / videoHeight.Value;
+                    var scale = Math.Min(scaleW, scaleH);
+
+                    var width = 2 * (int)((videoWidth.Value * scale) / 2);
+                    var height = 2 * (int)((videoHeight.Value * scale) / 2);
+                    return GetFixedSwScaleFilter(threedFormat, width, height);
+                }
+            }
+
             return string.Empty;
         }
 

--- a/MediaBrowser.Model/Configuration/EncodingOptions.cs
+++ b/MediaBrowser.Model/Configuration/EncodingOptions.cs
@@ -59,6 +59,8 @@ public class EncodingOptions
         EnableSubtitleExtraction = true;
         AllowOnDemandMetadataBasedKeyframeExtractionForExtensions = ["mkv"];
         HardwareDecodingCodecs = ["h264", "vc1"];
+        EnableUpscaling = false;
+        UpscaleMode = UpscaleMode.FullHD1080p;
     }
 
     /// <summary>
@@ -295,4 +297,14 @@ public class EncodingOptions
     /// Gets or sets the file extensions on-demand metadata based keyframe extraction is enabled for.
     /// </summary>
     public string[] AllowOnDemandMetadataBasedKeyframeExtractionForExtensions { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether video upscaling is enabled.
+    /// </summary>
+    public bool EnableUpscaling { get; set; }
+
+    /// <summary>
+    /// Gets or sets the target resolution for upscaling.
+    /// </summary>
+    public UpscaleMode UpscaleMode { get; set; }
 }

--- a/MediaBrowser.Model/Entities/UpscaleMode.cs
+++ b/MediaBrowser.Model/Entities/UpscaleMode.cs
@@ -1,0 +1,23 @@
+namespace MediaBrowser.Model.Entities;
+
+/// <summary>
+/// Defines the target resolution for video upscaling.
+/// </summary>
+public enum UpscaleMode
+{
+    /// <summary>
+    /// No upscaling.
+    /// </summary>
+    None = 0,
+
+    /// <summary>
+    /// Upscale to Full HD (1080p).
+    /// </summary>
+    FullHD1080p = 1,
+
+    /// <summary>
+    /// Upscale to Ultra HD (4K).
+    /// </summary>
+    UHD4K = 2
+}
+


### PR DESCRIPTION
## Summary
- add `UpscaleMode` enum defining FullHD and 4K targets
- expose `EnableUpscaling` and `UpscaleMode` in EncodingOptions
- migrate new fields in encoding options migration
- implement optional upscaling in software scaling filter
- fix newline in `UpscaleMode`

## Testing
- `dotnet test Jellyfin.sln -v n`

------
https://chatgpt.com/codex/tasks/task_e_684091eaece4832a9a71bcfe8600ca92