### PR TITLE
Fix typos and README grammar

### DIFF
--- a/MediaBrowser.MediaEncoding/Encoder/ApplePlatformHelper.cs
+++ b/MediaBrowser.MediaEncoding/Encoder/ApplePlatformHelper.cs
@@ -72,7 +72,7 @@ public static class ApplePlatformHelper
         }
         catch (Exception e)
         {
-            logger.LogError("Unknown error occured: {Exception}", e);
+            logger.LogError("Unknown error occurred: {Exception}", e);
         }
 
         return false;

--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ This creates a container that has everything to run and debug the Jellyfin Media
 > Keep in mind that as this has no web client you have to connect to it via an external client. This can be just another codespace container running the WebUI. vuejs does not work from the get-go as it does not support the setup steps.
 
 #### Development Jellyfin Server ffmpeg
-this extends the default server with a default installation of ffmpeg6 though the means described here: https://jellyfin.org/docs/general/installation/linux#repository-manual
+this extends the default server with a default installation of ffmpeg6 through the means described here: https://jellyfin.org/docs/general/installation/linux#repository-manual
 If you want to install a specific ffmpeg version, follow the comments embedded in the `.devcontainer/Dev - Server Ffmpeg/install.ffmpeg.sh` file.
 
 Use the `ghcs .NET Launch (nowebclient, ffmpeg)` launch config to run with the jellyfin-ffmpeg enabled.

--- a/src/Jellyfin.Database/Jellyfin.Database.Implementations/JellyfinQueryHelperExtensions.cs
+++ b/src/Jellyfin.Database/Jellyfin.Database.Implementations/JellyfinQueryHelperExtensions.cs
@@ -67,7 +67,8 @@ public static class JellyfinQueryHelperExtensions
         IList<Guid> referenceIds,
         bool invert = false)
     {
-        // Well genre/artist/album etc items do not actually set the ItemValue of thier specitic types so we cannot match it that way.
+        // Well genre/artist/album etc items do not actually set the ItemValue of their specific types,
+        // so we cannot match it that way.
         /*
         "(guid in (select itemid from ItemValues where CleanValue = (select CleanName from TypedBaseItems where guid=@GenreIds and Type=2)))"
         */


### PR DESCRIPTION
## Summary
- fix typos in database query helper comment and log message
- correct grammar in README instructions

## Issues
- addresses minor documentation and code comment issues found during repo review

------
https://chatgpt.com/codex/tasks/task_e_684097e17e88832a874debca8fbbd20c