### PR TITLE
Fix blocking loop in ProgressiveFileStream

### DIFF
--- a/MediaBrowser.Controller/Streaming/ProgressiveFileStream.cs
+++ b/MediaBrowser.Controller/Streaming/ProgressiveFileStream.cs
@@ -80,23 +80,9 @@ public class ProgressiveFileStream : Stream
     /// <inheritdoc />
     public override int Read(Span<byte> buffer)
     {
-        int totalBytesRead = 0;
-        var stopwatch = Stopwatch.StartNew();
-
-        while (true)
-        {
-            totalBytesRead += _stream.Read(buffer);
-            if (StopReading(totalBytesRead, stopwatch.ElapsedMilliseconds))
-            {
-                break;
-            }
-
-            Thread.Sleep(50);
-        }
-
-        UpdateBytesWritten(totalBytesRead);
-
-        return totalBytesRead;
+        var bytesRead = _stream.Read(buffer);
+        UpdateBytesWritten(bytesRead);
+        return bytesRead;
     }
 
     /// <inheritdoc />


### PR DESCRIPTION
## Summary
- stop looping in `ProgressiveFileStream.Read`
- rely on async version for wait logic

## Testing
- `dotnet test Jellyfin.sln` *(fails: SA1518 File is required to end with a single newline character)*

------
https://chatgpt.com/codex/tasks/task_e_6842a2505f14832a81325b7ee26e9f72