### PR TITLE
Fix weekly trigger UTC handling

### DIFF
--- a/Emby.Server.Implementations/ScheduledTasks/Triggers/WeeklyTrigger.cs
+++ b/Emby.Server.Implementations/ScheduledTasks/Triggers/WeeklyTrigger.cs
@@ -41,7 +41,7 @@ public sealed class WeeklyTrigger : ITaskTrigger, IDisposable
 
         var triggerDate = GetNextTriggerDateTime();
 
-        _timer = new Timer(_ => OnTriggered(), null, triggerDate - DateTime.Now, TimeSpan.FromMilliseconds(-1));
+        _timer = new Timer(_ => OnTriggered(), null, triggerDate - DateTime.UtcNow, TimeSpan.FromMilliseconds(-1));
     }
 
     /// <summary>
@@ -50,7 +50,7 @@ public sealed class WeeklyTrigger : ITaskTrigger, IDisposable
     /// <returns>DateTime.</returns>
     private DateTime GetNextTriggerDateTime()
     {
-        var now = DateTime.Now;
+        var now = DateTime.UtcNow;
 
         // If it's on the same day
         if (now.DayOfWeek == _dayOfWeek)


### PR DESCRIPTION
## Summary
- use `DateTime.UtcNow` in weekly task trigger calculations

## Testing
- `dotnet test Jellyfin.sln` *(fails: The argument ... is invalid)*

------
https://chatgpt.com/codex/tasks/task_e_6842a2550de0832a99df6e4256b6bae1