### PR TITLE
Fix LibraryMonitor async void

### DIFF
--- a/Emby.Server.Implementations/Collections/CollectionManager.cs
+++ b/Emby.Server.Implementations/Collections/CollectionManager.cs
@@ -192,7 +192,7 @@ namespace Emby.Server.Implementations.Collections
             finally
             {
                 // Refresh handled internally
-                _iLibraryMonitor.ReportFileSystemChangeComplete(path, false);
+                await _iLibraryMonitor.ReportFileSystemChangeComplete(path, false).ConfigureAwait(false);
             }
         }
 

--- a/Emby.Server.Implementations/IO/LibraryMonitor.cs
+++ b/Emby.Server.Implementations/IO/LibraryMonitor.cs
@@ -71,7 +71,7 @@ namespace Emby.Server.Implementations.IO
         }
 
         /// <inheritdoc />
-        public async void ReportFileSystemChangeComplete(string path, bool refreshPath)
+        public async Task ReportFileSystemChangeComplete(string path, bool refreshPath)
         {
             ArgumentException.ThrowIfNullOrEmpty(path);
 

--- a/Emby.Server.Implementations/Playlists/PlaylistManager.cs
+++ b/Emby.Server.Implementations/Playlists/PlaylistManager.cs
@@ -165,7 +165,7 @@ namespace Emby.Server.Implementations.Playlists
             finally
             {
                 // Refresh handled internally
-                _iLibraryMonitor.ReportFileSystemChangeComplete(path, false);
+                await _iLibraryMonitor.ReportFileSystemChangeComplete(path, false).ConfigureAwait(false);
             }
         }
 

--- a/MediaBrowser.Controller/Library/ILibraryMonitor.cs
+++ b/MediaBrowser.Controller/Library/ILibraryMonitor.cs
@@ -1,3 +1,5 @@
+using System.Threading.Tasks;
+
 namespace MediaBrowser.Controller.Library
 {
     /// <summary>
@@ -26,7 +28,8 @@ namespace MediaBrowser.Controller.Library
         /// </summary>
         /// <param name="path">The path.</param>
         /// <param name="refreshPath">if set to <c>true</c> [refresh path].</param>
-        void ReportFileSystemChangeComplete(string path, bool refreshPath);
+        /// <returns>A <see cref="Task"/> representing the completion of the operation.</returns>
+        Task ReportFileSystemChangeComplete(string path, bool refreshPath);
 
         /// <summary>
         /// Reports the file system changed.

--- a/MediaBrowser.Model/Entities/UpscaleMode.cs
+++ b/MediaBrowser.Model/Entities/UpscaleMode.cs
@@ -20,4 +20,3 @@ public enum UpscaleMode
     /// </summary>
     UHD4K = 2
 }
-

--- a/MediaBrowser.Providers/Lyric/LyricManager.cs
+++ b/MediaBrowser.Providers/Lyric/LyricManager.cs
@@ -228,7 +228,7 @@ public class LyricManager : ILyricManager
     }
 
     /// <inheritdoc />
-    public Task DeleteLyricsAsync(Audio audio)
+    public async Task DeleteLyricsAsync(Audio audio)
     {
         ArgumentNullException.ThrowIfNull(audio);
         var streams = _mediaSourceManager.GetMediaStreams(new MediaStreamQuery
@@ -248,11 +248,11 @@ public class LyricManager : ILyricManager
             }
             finally
             {
-                _libraryMonitor.ReportFileSystemChangeComplete(path, false);
+                await _libraryMonitor.ReportFileSystemChangeComplete(path, false).ConfigureAwait(false);
             }
         }
 
-        return audio.RefreshMetadata(CancellationToken.None);
+        await audio.RefreshMetadata(CancellationToken.None).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
@@ -454,7 +454,7 @@ public class LyricManager : ILyricManager
             }
             finally
             {
-                _libraryMonitor.ReportFileSystemChangeComplete(savePath, false);
+                await _libraryMonitor.ReportFileSystemChangeComplete(savePath, false).ConfigureAwait(false);
             }
 
             stream.Position = 0;

--- a/MediaBrowser.Providers/Manager/ImageSaver.cs
+++ b/MediaBrowser.Providers/Manager/ImageSaver.cs
@@ -217,7 +217,7 @@ namespace MediaBrowser.Providers.Manager
                 }
                 finally
                 {
-                    _libraryMonitor.ReportFileSystemChangeComplete(currentPath, false);
+                    await _libraryMonitor.ReportFileSystemChangeComplete(currentPath, false).ConfigureAwait(false);
                 }
             }
         }
@@ -310,8 +310,8 @@ namespace MediaBrowser.Providers.Manager
             }
             finally
             {
-                _libraryMonitor.ReportFileSystemChangeComplete(path, false);
-                _libraryMonitor.ReportFileSystemChangeComplete(parentFolder, false);
+                await _libraryMonitor.ReportFileSystemChangeComplete(path, false).ConfigureAwait(false);
+                await _libraryMonitor.ReportFileSystemChangeComplete(parentFolder, false).ConfigureAwait(false);
             }
         }
 

--- a/MediaBrowser.Providers/Manager/ProviderManager.cs
+++ b/MediaBrowser.Providers/Manager/ProviderManager.cs
@@ -699,7 +699,7 @@ namespace MediaBrowser.Providers.Manager
                     }
                     finally
                     {
-                        _libraryMonitor.ReportFileSystemChangeComplete(path, false);
+                        await _libraryMonitor.ReportFileSystemChangeComplete(path, false).ConfigureAwait(false);
                     }
                 }
                 else

--- a/MediaBrowser.Providers/Subtitles/SubtitleManager.cs
+++ b/MediaBrowser.Providers/Subtitles/SubtitleManager.cs
@@ -269,7 +269,7 @@ namespace MediaBrowser.Providers.Subtitles
                 }
                 finally
                 {
-                    _monitor.ReportFileSystemChangeComplete(path, false);
+                    await _monitor.ReportFileSystemChangeComplete(path, false).ConfigureAwait(false);
                 }
 
                 stream.Position = 0;
@@ -348,7 +348,7 @@ namespace MediaBrowser.Providers.Subtitles
         }
 
         /// <inheritdoc />
-        public Task DeleteSubtitles(BaseItem item, int index)
+        public async Task DeleteSubtitles(BaseItem item, int index)
         {
             var stream = _mediaSourceManager.GetMediaStreams(new MediaStreamQuery
             {
@@ -366,10 +366,10 @@ namespace MediaBrowser.Providers.Subtitles
             }
             finally
             {
-                _monitor.ReportFileSystemChangeComplete(path, false);
+                await _monitor.ReportFileSystemChangeComplete(path, false).ConfigureAwait(false);
             }
 
-            return item.RefreshMetadata(CancellationToken.None);
+            return await item.RefreshMetadata(CancellationToken.None).ConfigureAwait(false);
         }
 
         /// <inheritdoc />

--- a/src/Jellyfin.LiveTv/Recordings/RecordingsManager.cs
+++ b/src/Jellyfin.LiveTv/Recordings/RecordingsManager.cs
@@ -397,7 +397,7 @@ public sealed class RecordingsManager : IRecordingsManager, IDisposable
 
         DeleteFileIfEmpty(recordingPath);
         TriggerRefresh(recordingPath);
-        _libraryMonitor.ReportFileSystemChangeComplete(recordingPath, false);
+        await _libraryMonitor.ReportFileSystemChangeComplete(recordingPath, false).ConfigureAwait(false);
         _activeRecordings.TryRemove(timer.Id, out _);
 
         if (recordingStatus != RecordingStatus.Completed && DateTime.UtcNow < timer.EndDate && timer.RetryCount < 10)


### PR DESCRIPTION
## Summary
- make `ReportFileSystemChangeComplete` return `Task`
- document return value in `ILibraryMonitor`
- await calls to `ReportFileSystemChangeComplete`
- fix trailing newline in `UpscaleMode`

## Testing
- `dotnet test Jellyfin.sln`

------
https://chatgpt.com/codex/tasks/task_e_6842a1db6d60832aa907f8c03f7672cb