### PR TITLE
Fix user rename casing

### DIFF
--- a/Jellyfin.Server.Implementations/Users/UserManager.cs
+++ b/Jellyfin.Server.Implementations/Users/UserManager.cs
@@ -161,7 +161,7 @@ namespace Jellyfin.Server.Implementations.Users
 #pragma warning disable CA1311 // Specify a culture or use an invariant version to avoid implicit dependency on current culture
 #pragma warning disable CA1304 // The behavior of 'string.ToUpper()' could vary based on the current user's locale settings
                 if (await dbContext.Users
-                        .AnyAsync(u => u.Username.ToUpper() == newName.ToUpper() && !u.Id.Equals(user.Id))
+                        .AnyAsync(u => u.Username.ToUpperInvariant() == newName.ToUpperInvariant() && !u.Id.Equals(user.Id))
                         .ConfigureAwait(false))
                 {
                     throw new ArgumentException(string.Format(

--- a/MediaBrowser.Model/Entities/UpscaleMode.cs
+++ b/MediaBrowser.Model/Entities/UpscaleMode.cs
@@ -20,4 +20,3 @@ public enum UpscaleMode
     /// </summary>
     UHD4K = 2
 }
-


### PR DESCRIPTION
## Summary
- call `ToUpperInvariant` when comparing usernames in `UserManager`
- normalize newline at end of `UpscaleMode.cs`

## Testing
- `dotnet test Jellyfin.sln -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_6842a241d060832a82132118db9247ea