### PR TITLE
Fix null check in session inactivity timer

### DIFF
--- a/Emby.Server.Implementations/Session/SessionManager.cs
+++ b/Emby.Server.Implementations/Session/SessionManager.cs
@@ -686,7 +686,8 @@ namespace Emby.Server.Implementations.Session
             var inactiveSessions = Sessions.Where(i =>
                     i.NowPlayingItem is not null
                     && i.PlayState.IsPaused
-                    && (DateTime.UtcNow - i.LastPausedDate).Value.TotalMinutes > _config.Configuration.InactiveSessionThreshold);
+                    && i.LastPausedDate.HasValue
+                    && (DateTime.UtcNow - i.LastPausedDate.Value).TotalMinutes > _config.Configuration.InactiveSessionThreshold);
 
             foreach (var session in inactiveSessions)
             {


### PR DESCRIPTION
## Summary
- guard LastPausedDate before subtracting in SessionManager

## Testing
- `dotnet test Jellyfin.sln`

------
https://chatgpt.com/codex/tasks/task_e_6842a24638b8832a82508e0dc8c71eaf