### PR TITLE
Fix async handling in StartupTrigger

### DIFF
--- a/Emby.Server.Implementations/ScheduledTasks/ScheduledTaskWorker.cs
+++ b/Emby.Server.Implementations/ScheduledTasks/ScheduledTaskWorker.cs
@@ -186,7 +186,7 @@ public class ScheduledTaskWorker : IScheduledTaskWorker
 
             _triggers = value.ToArray();
 
-            ReloadTriggerEvents(false);
+            ReloadTriggerEvents(false).GetAwaiter().GetResult();
         }
     }
 
@@ -223,20 +223,20 @@ public class ScheduledTaskWorker : IScheduledTaskWorker
     private void InitTriggerEvents()
     {
         _triggers = LoadTriggers();
-        ReloadTriggerEvents(true);
+        ReloadTriggerEvents(true).GetAwaiter().GetResult();
     }
 
     /// <inheritdoc />
-    public void ReloadTriggerEvents()
+    public Task ReloadTriggerEvents()
     {
-        ReloadTriggerEvents(false);
+        return ReloadTriggerEvents(false);
     }
 
     /// <summary>
     /// Reloads the trigger events.
     /// </summary>
     /// <param name="isApplicationStartup">if set to <c>true</c> [is application startup].</param>
-    private void ReloadTriggerEvents(bool isApplicationStartup)
+    private async Task ReloadTriggerEvents(bool isApplicationStartup)
     {
         foreach (var triggerInfo in InternalTriggers)
         {
@@ -246,7 +246,7 @@ public class ScheduledTaskWorker : IScheduledTaskWorker
 
             trigger.Triggered -= OnTriggerTriggered;
             trigger.Triggered += OnTriggerTriggered;
-            trigger.Start(LastExecutionResult, _logger, Name, isApplicationStartup);
+            await trigger.Start(LastExecutionResult, _logger, Name, isApplicationStartup).ConfigureAwait(false);
         }
     }
 
@@ -272,7 +272,7 @@ public class ScheduledTaskWorker : IScheduledTaskWorker
 
         await Task.Delay(1000).ConfigureAwait(false);
 
-        trigger.Start(LastExecutionResult, _logger, Name, false);
+        await trigger.Start(LastExecutionResult, _logger, Name, false).ConfigureAwait(false);
     }
 
     /// <summary>

--- a/Emby.Server.Implementations/ScheduledTasks/Triggers/DailyTrigger.cs
+++ b/Emby.Server.Implementations/ScheduledTasks/Triggers/DailyTrigger.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Threading;
+using System.Threading.Tasks;
 using MediaBrowser.Model.Tasks;
 using Microsoft.Extensions.Logging;
 
@@ -32,7 +33,7 @@ public sealed class DailyTrigger : ITaskTrigger, IDisposable
     public TaskOptions TaskOptions { get; }
 
     /// <inheritdoc />
-    public void Start(TaskResult? lastResult, ILogger logger, string taskName, bool isApplicationStartup)
+    public Task Start(TaskResult? lastResult, ILogger logger, string taskName, bool isApplicationStartup)
     {
         DisposeTimer();
 
@@ -46,6 +47,8 @@ public sealed class DailyTrigger : ITaskTrigger, IDisposable
         logger.LogInformation("Daily trigger for {Task} set to fire at {TriggerDate:yyyy-MM-dd HH:mm:ss.fff zzz}, which is {DueTime:c} from now.", taskName, triggerDate, dueTime);
 
         _timer = new Timer(_ => OnTriggered(), null, dueTime, TimeSpan.FromMilliseconds(-1));
+
+        return Task.CompletedTask;
     }
 
     /// <inheritdoc />

--- a/Emby.Server.Implementations/ScheduledTasks/Triggers/IntervalTrigger.cs
+++ b/Emby.Server.Implementations/ScheduledTasks/Triggers/IntervalTrigger.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Linq;
 using System.Threading;
+using System.Threading.Tasks;
 using MediaBrowser.Model.Tasks;
 using Microsoft.Extensions.Logging;
 
@@ -34,7 +35,7 @@ public sealed class IntervalTrigger : ITaskTrigger, IDisposable
     public TaskOptions TaskOptions { get; }
 
     /// <inheritdoc />
-    public void Start(TaskResult? lastResult, ILogger logger, string taskName, bool isApplicationStartup)
+    public Task Start(TaskResult? lastResult, ILogger logger, string taskName, bool isApplicationStartup)
     {
         DisposeTimer();
 
@@ -60,6 +61,8 @@ public sealed class IntervalTrigger : ITaskTrigger, IDisposable
         }
 
         _timer = new Timer(_ => OnTriggered(), null, dueTime, TimeSpan.FromMilliseconds(-1));
+
+        return Task.CompletedTask;
     }
 
     /// <inheritdoc />

--- a/Emby.Server.Implementations/ScheduledTasks/Triggers/StartupTrigger.cs
+++ b/Emby.Server.Implementations/ScheduledTasks/Triggers/StartupTrigger.cs
@@ -28,12 +28,18 @@ public sealed class StartupTrigger : ITaskTrigger
     public TaskOptions TaskOptions { get; }
 
     /// <inheritdoc />
-    public async void Start(TaskResult? lastResult, ILogger logger, string taskName, bool isApplicationStartup)
+    public Task Start(TaskResult? lastResult, ILogger logger, string taskName, bool isApplicationStartup)
     {
         if (isApplicationStartup)
         {
-            await Task.Delay(DelayMs).ConfigureAwait(false);
+            return DelayStart();
+        }
 
+        return Task.CompletedTask;
+
+        async Task DelayStart()
+        {
+            await Task.Delay(DelayMs).ConfigureAwait(false);
             OnTriggered();
         }
     }

--- a/Emby.Server.Implementations/ScheduledTasks/Triggers/WeeklyTrigger.cs
+++ b/Emby.Server.Implementations/ScheduledTasks/Triggers/WeeklyTrigger.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Threading;
+using System.Threading.Tasks;
 using MediaBrowser.Model.Tasks;
 using Microsoft.Extensions.Logging;
 
@@ -35,13 +36,15 @@ public sealed class WeeklyTrigger : ITaskTrigger, IDisposable
     public TaskOptions TaskOptions { get; }
 
     /// <inheritdoc />
-    public void Start(TaskResult? lastResult, ILogger logger, string taskName, bool isApplicationStartup)
+    public Task Start(TaskResult? lastResult, ILogger logger, string taskName, bool isApplicationStartup)
     {
         DisposeTimer();
 
         var triggerDate = GetNextTriggerDateTime();
 
         _timer = new Timer(_ => OnTriggered(), null, triggerDate - DateTime.Now, TimeSpan.FromMilliseconds(-1));
+
+        return Task.CompletedTask;
     }
 
     /// <summary>

--- a/MediaBrowser.Model/Entities/UpscaleMode.cs
+++ b/MediaBrowser.Model/Entities/UpscaleMode.cs
@@ -20,4 +20,3 @@ public enum UpscaleMode
     /// </summary>
     UHD4K = 2
 }
-

--- a/MediaBrowser.Model/Tasks/IScheduledTaskWorker.cs
+++ b/MediaBrowser.Model/Tasks/IScheduledTaskWorker.cs
@@ -1,6 +1,7 @@
 #nullable disable
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using Jellyfin.Data.Events;
 
 namespace MediaBrowser.Model.Tasks
@@ -72,6 +73,7 @@ namespace MediaBrowser.Model.Tasks
         /// <summary>
         /// Reloads the trigger events.
         /// </summary>
-        void ReloadTriggerEvents();
+        /// <returns>A <see cref="Task"/> representing the operation.</returns>
+        Task ReloadTriggerEvents();
     }
 }

--- a/MediaBrowser.Model/Tasks/ITaskTrigger.cs
+++ b/MediaBrowser.Model/Tasks/ITaskTrigger.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 
 namespace MediaBrowser.Model.Tasks
@@ -25,7 +26,8 @@ namespace MediaBrowser.Model.Tasks
         /// <param name="logger">The <see cref="ILogger"/>.</param>
         /// <param name="taskName">The name of the task.</param>
         /// <param name="isApplicationStartup">Whether or not this is fired during startup.</param>
-        void Start(TaskResult? lastResult, ILogger logger, string taskName, bool isApplicationStartup);
+        /// <returns>A <see cref="Task"/> representing the operation.</returns>
+        Task Start(TaskResult? lastResult, ILogger logger, string taskName, bool isApplicationStartup);
 
         /// <summary>
         /// Stops waiting for the trigger action.


### PR DESCRIPTION
## Summary
- convert `StartupTrigger.Start` to return `Task`
- await the startup trigger delay
- update ITaskTrigger interface and all trigger implementations
- await trigger startup calls in `ScheduledTaskWorker`
- make `IScheduledTaskWorker.ReloadTriggerEvents` return `Task`

## Testing
- `dotnet test Jellyfin.sln -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_6842a24c47bc832aaee4ccdc2b22e714