### PR TITLE
Refuse non-empty unowned custom transcode directories

### DIFF
--- a/MediaBrowser.Common/Configuration/EncodingConfigurationExtensions.cs
+++ b/MediaBrowser.Common/Configuration/EncodingConfigurationExtensions.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using System.Linq;
 using MediaBrowser.Model.Configuration;
 
 namespace MediaBrowser.Common.Configuration
@@ -9,6 +10,8 @@ namespace MediaBrowser.Common.Configuration
     /// </summary>
     public static class EncodingConfigurationExtensions
     {
+        private const string TranscodeMarkerName = ".jellyfin-transcode";
+
         /// <summary>
         /// Gets the encoding options.
         /// </summary>
@@ -26,17 +29,40 @@ namespace MediaBrowser.Common.Configuration
         /// <exception cref="UnauthorizedAccessException">If the directory does not exist, and the caller does not have the required permission to create it.</exception>
         /// <exception cref="NotSupportedException">If there is a custom path transcoding path specified, but it is invalid.</exception>
         /// <exception cref="IOException">If the directory does not exist, and it also could not be created.</exception>
+        /// <exception cref="InvalidOperationException">If the configured custom path is non-empty and is not already owned by Jellyfin.</exception>
         public static string GetTranscodePath(this IConfigurationManager configurationManager)
         {
             // Get the configured path and fall back to a default
             var transcodingTempPath = configurationManager.GetEncodingOptions().TranscodingTempPath;
-            if (string.IsNullOrEmpty(transcodingTempPath))
+            var isCustomPath = !string.IsNullOrEmpty(transcodingTempPath);
+            if (!isCustomPath)
             {
                 transcodingTempPath = Path.Combine(configurationManager.CommonApplicationPaths.CachePath, "transcodes");
             }
 
+            if (isCustomPath && !CanClaimTranscodeDirectory(transcodingTempPath))
+            {
+                throw new InvalidOperationException(
+                    $"Refusing to use non-empty transcode directory '{transcodingTempPath}' because it is not marked as owned by Jellyfin.");
+            }
+
             configurationManager.CommonApplicationPaths.CreateAndCheckMarker(transcodingTempPath, "transcode", true);
             return transcodingTempPath;
+        }
+
+        private static bool CanClaimTranscodeDirectory(string path)
+        {
+            if (!Directory.Exists(path))
+            {
+                return true;
+            }
+
+            if (File.Exists(Path.Combine(path, TranscodeMarkerName)))
+            {
+                return true;
+            }
+
+            return !Directory.EnumerateFileSystemEntries(path).Any();
         }
     }
 }

--- a/tests/Jellyfin.Server.Tests/Configuration/EncodingConfigurationExtensionsTests.cs
+++ b/tests/Jellyfin.Server.Tests/Configuration/EncodingConfigurationExtensionsTests.cs
@@ -1,0 +1,127 @@
+using System;
+using System.IO;
+using MediaBrowser.Common.Configuration;
+using MediaBrowser.Model.Configuration;
+using Moq;
+using Xunit;
+
+namespace Jellyfin.Server.Tests.Configuration
+{
+    public static class EncodingConfigurationExtensionsTests
+    {
+        [Fact]
+        public static void GetTranscodePath_MissingCustomDirectory_ClaimsConfiguredPath()
+        {
+            var path = Path.Combine(Path.GetTempPath(), "jellyfin-transcode-tests", Guid.NewGuid().ToString("N"));
+            var (configuration, applicationPaths) = CreateConfiguration(path);
+
+            Assert.Equal(path, configuration.Object.GetTranscodePath());
+            applicationPaths.Verify(p => p.CreateAndCheckMarker(path, "transcode", true), Times.Once);
+        }
+
+        [Fact]
+        public static void GetTranscodePath_EmptyCustomDirectory_ClaimsConfiguredPath()
+        {
+            var path = CreateTempDirectory();
+            try
+            {
+                var (configuration, applicationPaths) = CreateConfiguration(path);
+
+                Assert.Equal(path, configuration.Object.GetTranscodePath());
+                applicationPaths.Verify(p => p.CreateAndCheckMarker(path, "transcode", true), Times.Once);
+            }
+            finally
+            {
+                Directory.Delete(path, true);
+            }
+        }
+
+        [Fact]
+        public static void GetTranscodePath_NonEmptyUnmarkedCustomDirectory_ThrowsBeforeClaimingPath()
+        {
+            var path = CreateTempDirectory();
+            try
+            {
+                File.WriteAllText(Path.Combine(path, "unrelated-user-file.txt"), "keep me");
+                var (configuration, applicationPaths) = CreateConfiguration(path);
+
+                Assert.Throws<InvalidOperationException>(() => configuration.Object.GetTranscodePath());
+                applicationPaths.Verify(p => p.CreateAndCheckMarker(path, "transcode", true), Times.Never);
+            }
+            finally
+            {
+                Directory.Delete(path, true);
+            }
+        }
+
+        [Fact]
+        public static void GetTranscodePath_CustomDirectoryWithSubdirectory_ThrowsBeforeClaimingPath()
+        {
+            var path = CreateTempDirectory();
+            try
+            {
+                Directory.CreateDirectory(Path.Combine(path, "unrelated-user-directory"));
+                var (configuration, applicationPaths) = CreateConfiguration(path);
+
+                Assert.Throws<InvalidOperationException>(() => configuration.Object.GetTranscodePath());
+                applicationPaths.Verify(p => p.CreateAndCheckMarker(path, "transcode", true), Times.Never);
+            }
+            finally
+            {
+                Directory.Delete(path, true);
+            }
+        }
+
+        [Fact]
+        public static void GetTranscodePath_MarkedCustomDirectoryWithContent_ReturnsConfiguredPath()
+        {
+            var path = CreateTempDirectory();
+            try
+            {
+                File.WriteAllText(Path.Combine(path, ".jellyfin-transcode"), string.Empty);
+                File.WriteAllText(Path.Combine(path, "existing-transcode.ts"), "data");
+                var (configuration, applicationPaths) = CreateConfiguration(path);
+
+                Assert.Equal(path, configuration.Object.GetTranscodePath());
+                applicationPaths.Verify(p => p.CreateAndCheckMarker(path, "transcode", true), Times.Once);
+            }
+            finally
+            {
+                Directory.Delete(path, true);
+            }
+        }
+
+        [Fact]
+        public static void GetTranscodePath_DefaultPath_DoesNotRequirePreexistingMarker()
+        {
+            var cachePath = Path.Combine(Path.GetTempPath(), "jellyfin-transcode-tests", Guid.NewGuid().ToString("N"));
+            var expectedPath = Path.Combine(cachePath, "transcodes");
+            var (configuration, applicationPaths) = CreateConfiguration(null, cachePath);
+
+            Assert.Equal(expectedPath, configuration.Object.GetTranscodePath());
+            applicationPaths.Verify(p => p.CreateAndCheckMarker(expectedPath, "transcode", true), Times.Once);
+        }
+
+        private static (Mock<IConfigurationManager> Configuration, Mock<IApplicationPaths> ApplicationPaths) CreateConfiguration(
+            string? transcodePath,
+            string? cachePath = null)
+        {
+            var applicationPaths = new Mock<IApplicationPaths>();
+            applicationPaths.SetupGet(p => p.CachePath).Returns(cachePath ?? Path.GetTempPath());
+
+            var configuration = new Mock<IConfigurationManager>();
+            configuration.Setup(c => c.GetConfiguration("encoding"))
+                .Returns(new EncodingOptions { TranscodingTempPath = transcodePath });
+            configuration.SetupGet(c => c.CommonApplicationPaths).Returns(applicationPaths.Object);
+
+            return (configuration, applicationPaths);
+        }
+
+        private static string CreateTempDirectory()
+        {
+            var path = Path.Combine(Path.GetTempPath(), "jellyfin-transcode-tests", Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(path);
+            return path;
+        }
+    }
+}


### PR DESCRIPTION
**Changes**
Prevent Jellyfin from newly claiming a non-empty custom transcoding directory that does not already carry Jellyfin's transcode ownership marker. Missing or empty custom directories can still be claimed, already-marked directories continue to work, and the default Jellyfin-owned transcode path is unchanged. Adds regression tests through the public `GetTranscodePath()` API.

**Code assistance**
Implemented with ChatGPT assistance. The assistant identified the open issue, inspected the current marker and cleanup code plus related maintainer discussions, generated the implementation and tests, and iterated after CI exposed an invalid initial test seam. This final branch is rebuilt directly from current upstream `master` with only the finished implementation and tests.

**Issues**
Addresses the transcode-path case in jellyfin/jellyfin#9785. Cache/log path hardening is intentionally left out of this focused change.